### PR TITLE
update script to work with current debian

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #This script downloads Debians's iso and makes it auto-install
 #Requires:
@@ -12,23 +12,23 @@
 #	     debconf-get-selections --installer >> preseed.cfg
 
 #####[ MD5 Fix func ]#####
-function fixSum {
+fixSum() {
 	FILE=$1
 	PLACE=$2
 
-	MD5_LINE_BEFORE=$( cat md5sum.txt | grep $PLACE )
+	MD5_LINE_BEFORE=$( grep "$PLACE" md5sum.txt)
 	MD5_BEFORE=$( echo "$MD5_LINE_BEFORE" | awk '{ print $1 }' )
-	MD5_AFTER=$( md5sum $FILE | awk '{ print $1 }' )
+	MD5_AFTER=$( md5sum "$FILE" | awk '{ print $1 }' )
 	MD5_LINE_AFTER=$( echo "$MD5_LINE_BEFORE" | sed -e "s#$MD5_BEFORE#$MD5_AFTER#" )
 	sed -i -e "s#$MD5_LINE_BEFORE#$MD5_LINE_AFTER#" md5sum.txt
 }
 
 #####[ Getting latest iso ]#####
-BASE_URL=https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/
-ISO=$( wget -qO -  $BASE_URL/MD5SUMS | grep netinst | grep -v mac | head -n 1 | awk '{ print $2 }' )
+BASE_URL=https://cdimage.debian.org/debian-cd/current/amd64/iso-cd
+ISO=$( wget -qO - $BASE_URL/SHA512SUMS | grep netinst | grep -v mac | head -n 1 | awk '{ print $2 }' )
 
-if [ ! -f $ISO ]; then
-	wget $BASE_URL/$ISO -O $ISO
+if [ ! -f "$ISO" ]; then
+	wget "$BASE_URL/$ISO" -O "$ISO"
 fi
 
 #####[ Working directory ]#####
@@ -39,40 +39,40 @@ mkdir $WORKDIR
 
 #####[ Building name of new iso ]#####
 
-ISO_SRC=$( find -name '*.iso' | grep -v preseed | head -n 1 )
+ISO_SRC=$( find . -name '*.iso' | grep -v preseed | head -n 1 )
 ISO_PREFIX=$( echo "$ISO_SRC" | sed 's/.iso//' )
-ISO_TARGET=$( echo "$ISO_PREFIX-preseed.iso" )
+ISO_TARGET="$ISO_PREFIX-preseed.iso"
 
 #####[ Extracting files from iso ]#####
-xorriso -osirrox on -dev $ISO_SRC \
+xorriso -osirrox on -dev "$ISO_SRC" \
 	-extract '/isolinux/isolinux.cfg' $WORKDIR/isolinux.cfg \
 	-extract '/md5sum.txt' $WORKDIR/md5sum.txt \
 	-extract '/install.amd/gtk/initrd.gz' $WORKDIR/initrd.gz
 
 #####[ Adding preseed to initrd ]#####
 cp preseed.cfg $WORKDIR/
-cd $WORKDIR
-gunzip initrd.gz
-chmod +w initrd
-echo "preseed.cfg" | cpio -o -H newc -A -F initrd
-gzip initrd
+(
+	cd $WORKDIR &&
+	gunzip initrd.gz
+	chmod +w initrd
+	echo "preseed.cfg" | cpio -o -H newc -A -F initrd
+	gzip initrd
 
-#####[ Changing default boot menu timeout ]#####
-sed -i 's/timeout 0/timeout 1/' isolinux.cfg
+	#####[ Changing default boot menu timeout ]#####
+	sed -i 's/timeout 0/timeout 1/' isolinux.cfg
 
-#####[ Fixing MD5 ]#####
-fixSum initrd.gz ./install.amd/gtk/initrd.gz
-fixSum isolinux.cfg ./isolinux/isolinux.cfg
-
-cd ..
+	#####[ Fixing MD5 ]#####
+	fixSum initrd.gz ./install.amd/gtk/initrd.gz
+	fixSum isolinux.cfg ./isolinux/isolinux.cfg
+)
 
 #####[ Writing new iso ]#####
-rm $ISO_TARGET
-xorriso -indev $ISO_SRC \
-	-map  $WORKDIR/isolinux.cfg '/isolinux/isolinux.cfg' \
-	-map  $WORKDIR/md5sum.txt '/md5sum.txt' \
+rm "$ISO_TARGET"
+xorriso -indev "$ISO_SRC" \
+	-map $WORKDIR/isolinux.cfg '/isolinux/isolinux.cfg' \
+	-map $WORKDIR/md5sum.txt '/md5sum.txt' \
 	-map $WORKDIR/initrd.gz '/install.amd/gtk/initrd.gz' \
 	-boot_image isolinux dir=/isolinux \
-	-outdev $ISO_TARGET
+	-outdev "$ISO_TARGET"
 
 rm -rf $WORKDIR


### PR DESCRIPTION
changed to check for the ISO file name using the SHA512SUMS file, since MD5SUMS doesn't exist upstream anymore

changed variable quoting here and there from recommendations of shellcheck utility
made the part where it moves to the workdir be in a subshell, which removes the need to worry about moving back

changed to be /bin/sh for portability